### PR TITLE
Allow protocol=0, default to HIGHEST_PROTOCOL

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,11 @@ Pickleclip will copy any python object supported by pickle (or dill) into your c
 
 ### Copying from Python 3 to Python 2 using pickle
 
-There are some known compatibility problems with copying and pasting code from Python 3 to Python 2, but some of those problems can be solved by using the `protocol` kwarg:
+To get Python 3 objects to unpickle on Python 2, specify `protocol=2` when copying. Although pickle will try to map the new Python 3 names to the old module names used in Python 2, so that the pickle data stream is readable with Python 2, this does not come without limitations.
+
+Going from Python 2 to Python 3 is even less trivial, and will mostly only work for the simplest cases. See also [pickle-compat](https://pypi.org/project/pickle-compat/).
+
+By default, the highest [pickle protocol](https://docs.python.org/3/library/pickle.html#pickle-protocols) available to the interpreter is used. The higher the protocol used, the more recent the version of Python needed to read the pickle produced.
 
 ##### Python 3 shell:
 
@@ -71,8 +75,6 @@ In [1]: import pickleclip as picklec
 In [2]: picklec.paste()
 Out[2]: {'hello': 'world'}
 ```
-
-Since the PY2's pickle version can't handle the PY3's protocol number (which is 3), you'll need to force the PY3 pickle to use `protocol = 2`.
 
 ### Copying from different Python versions using dill
 

--- a/pickleclip/base.py
+++ b/pickleclip/base.py
@@ -7,8 +7,7 @@ import pyperclip
 import six
 
 
-def copy(obj, protocol=None, serializer=pickle):
-    protocol = protocol or (2 if six.PY2 else 3)
+def copy(obj, protocol=-1, serializer=pickle):
     dump = serializer.dumps(obj, protocol=protocol)
     pyperclip.copy(dump.decode('latin1'))
 


### PR DESCRIPTION
- The `or` statement prevented setting protocol=0
- Both pickle and dill default to HIGHEST_PROTOCOL when a negative integer is passed. Protocol 4 and 5 (3.4+, 3.8+) provide numerous advantages: https://docs.python.org/3/library/pickle.html#pickle-protocols